### PR TITLE
build: remove onnxruntime option

### DIFF
--- a/.github/workflows/rust_verify.yml
+++ b/.github/workflows/rust_verify.yml
@@ -57,11 +57,6 @@ on:
         type: string
         default: postgres:15.1-alpine
         description: "Version of postgres to use in sqlx jobs"
-      onnxruntime:
-        required: false
-        type: boolean
-        default: false
-        description: "Whether to download the onnxruntime"
       cargo-features:
         required: false
         type: string
@@ -158,12 +153,6 @@ jobs:
       - name: build images
         if: ${{ inputs.image-build-command }}
         run: ${{ inputs.image-build-command }}
-      - name: download onnxruntime
-        if: ${{ inputs.onnxruntime }}
-        run: |
-          wget "https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-linux-x64-1.17.0.tgz"
-          tar xvf onnxruntime-linux-x64-1.17.0.tgz
-          export ORT_DYLIB_PATH=$PWD/onnxruntime-linux-x64-1.17.0/lib/libonnxruntime.so.1.17.0
       - name: cargo test
         run: |
           cd ${{ inputs.src-dir }}


### PR DESCRIPTION
We leave it to the build script of the `ort` crate to do this.